### PR TITLE
Update Lottie animation to swift 5.8 compatible

### DIFF
--- a/RaveSDK/Classes/Utils/LoadingHUD.swift
+++ b/RaveSDK/Classes/Utils/LoadingHUD.swift
@@ -11,7 +11,7 @@ import Lottie
 
 class LoadingHUD: UIView {
     //let appDelegate = UIApplication.shared.delegate as? AppDelegate
-    var animation:AnimationView!
+    var animation:LottieAnimationView!
     
     var bgColor: UIColor? = .clear
     var applyBlur = true
@@ -58,7 +58,7 @@ class LoadingHUD: UIView {
         }
 		
         
-		animation = AnimationView(name: animationFile, bundle: Bundle.getResourcesBundle() ?? Bundle.main)
+		animation = LottieAnimationView(name: animationFile, bundle: Bundle.getResourcesBundle() ?? Bundle.main)
         animation.loopMode = .loop
         animation.translatesAutoresizingMaskIntoConstraints = false
         addSubview(animation)
@@ -81,7 +81,7 @@ class LoadingHUD: UIView {
             blurView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
         }
         
-        animation = AnimationView(name: animationFile)
+        animation = LottieAnimationView(name: animationFile)
         animation.loopMode = .loop
         animation.translatesAutoresizingMaskIntoConstraints = false
         addSubview(animation)


### PR DESCRIPTION
#### Description
Change Animation View to Lottie Animation View for Xcode 14 and swift 5.8 compatibility along side other recent XCode versions

#### Related Issue
https://github.com/Flutterwave/RaveSDK/issues/28

#### Motivation and Context
For already existing projects already integrating rave Flutterwave SDK, updating the Xcode IDE and swift version, breaks the Lottie animation from the Rave SDK

#### How Has This Been Tested?
This was tested in my project currently live on the store, where I had to manually go into the RaveSDK to update the animation view in order to build the project successfully.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ `x`] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [ `x`] My code follows the code style of this project.
- [ `x`] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. This is just a rename of the lottie animation view class from the lottie
- [`x` ] All new and existing tests passed.
- [ `x`] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`


@Flutterwave/Corvus97 What do you think about these updates?
